### PR TITLE
Configure jshint to allow global expect, inject, and waitsFor for tests

### DIFF
--- a/grunt/conf/jshint.js
+++ b/grunt/conf/jshint.js
@@ -33,7 +33,10 @@ module.exports = {
       afterEach: false,
       it: false,
       before: false,
-      after: false
+      after: false,
+      expect: false,
+      inject: false,
+      waitsFor: false
     }
   },
   src: [


### PR DESCRIPTION
Needed to add these to `jshint` so that `grunt` would build.
## Before

``` shell
$ grunt
Running "clean:0" (clean) task
Cleaning dist...OK

Running "clean:1" (clean) task

Running "jshint:src" (jshint) task
>> 3 files lint free.

Running "jshint:test" (jshint) task

   test/unit/service.test.js
      6 |  beforeEach(inject(function(flare) {
                      ^ 'inject' is not defined.
     11 |    expect(Object.keys(flareSvc.messages).length).toEqual(0);
             ^ 'expect' is not defined.
     17 |    expect(keys.length).toEqual(1);
             ^ 'expect' is not defined.
     19 |    expect(msg.ttl).toBeUndefined();
             ^ 'expect' is not defined.
     20 |    expect(msg.timeout).toBeUndefined();
             ^ 'expect' is not defined.
     21 |    expect(msg.content).toEqual('msg!');
             ^ 'expect' is not defined.
     23 |    expect(Object.keys(flareSvc.messages).length).toEqual(0);
             ^ 'expect' is not defined.
     30 |    expect(keys.length).toEqual(1);
             ^ 'expect' is not defined.
     32 |    expect(msg.ttl).toEqual(ttl);
             ^ 'expect' is not defined.
     33 |    expect(msg.timeout).not.toBeNull();
             ^ 'expect' is not defined.
     35 |    waitsFor(function() {
             ^ 'waitsFor' is not defined.
     52 |    waitsFor(function() {
             ^ 'waitsFor' is not defined.
     55 |    waitsFor(function() {
             ^ 'waitsFor' is not defined.

>> 13 errors in 1 file
Warning: Task "jshint:test" failed. Use --force to continue.

Aborted due to warnings.
```
